### PR TITLE
makeRemote: redo with executor API

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,8 +1,7 @@
 // Type definitions for eventual-send
 // FIXME: Add jsdocs.
 
-interface RemoteRelayer<R> {
-  AWAIT_FAR(): EPromise<unknown>;
+interface ERelay {
   GET(p: EPromise<unknown>, name: string | number | symbol): EPromise<unknown>;
   PUT(p: EPromise<unknown>, name: string | number | symbol, value: unknown): EPromise<void>;
   DELETE(p: EPromise<unknown>, name: string | number | symbol): EPromise<boolean>;
@@ -12,7 +11,7 @@ interface RemoteRelayer<R> {
 export interface EPromise<R> extends Promise<R> {
   get(name: string | number | symbol): EPromise<unknown>;
   put(name: string | number | symbol, value: unknown): EPromise<void>;
-  del(name: string | number | symbol): EPromise<boolean>;
+  delete(name: string | number | symbol): EPromise<boolean>;
   post(name?: string | number | symbol, args: unknown[]): EPromise<unknown>;
   invoke(name: string | number | symbol, ...args: unknown[]): EPromise<unknown>;
   fapply(args: unknown[]): EPromise<unknown>;
@@ -39,14 +38,19 @@ interface RejectedStatus {
 
 type SettledStatus = FulfilledStatus | RejectedStatus;
 
+type RemoteExecutor<R> = (
+  resolveRemote: (value?: R, resolvedRelay?: ERelay) => void,
+  rejectRemote: (reason?: unknown) => void,
+) => void;
+
 interface EPromiseConstructor extends PromiseConstructor {
   prototype: EPromise<unknown>;
-  makeRemote(relayer: RemoteRelayer<R>): EPromise<unknown>;
-  resolve<R>(specimen: R): EPromise<R>;
+  makeRemote<R>(executor: RemoteExecutor<R>, unresolvedRelay?: ERelay): EPromise<R>;
+  resolve<R>(value: R): EPromise<R>;
   reject(reason: unknown): EPromise<never>;
-  all(iterable: Iterable | AsyncIterable): EPromise<unknown[]>;
-  allSettled(iterable: Iterable | AsyncIterable): EPromise<SettledStatus[]>;
-  race(iterable: Iterable | AsyncIterable): EPromise<unknown>; 
+  all(iterable: Iterable): EPromise<unknown[]>;
+  allSettled(iterable: Iterable): EPromise<SettledStatus[]>;
+  race(iterable: Iterable): EPromise<unknown>; 
 }
 
 export default function makeEPromiseClass(Promise: PromiseConstructor): EPromiseConstructor;

--- a/test/test.js
+++ b/test/test.js
@@ -12,18 +12,162 @@ if (typeof window !== 'undefined') {
   });
 }
 
-test('EPromise.all', async t => {
+test('EPromise.makeRemote expected errors', async t => {
   try {
     const EPromise = makeEPromiseClass(Promise);
 
-    t.deepEqual(await EPromise.all([1, Promise.resolve(2), 3]), [1, 2, 3]);
+    const relay = {
+      GET(key) {
+        return key;
+      },
+      DELETE(_key) {
+        return true;
+      },
+      PUT(key, value) {
+        return value;
+      },
+      POST(key, args) {
+        return args;
+      },
+    };
 
-    // eslint-disable-next-line no-inner-declarations
-    function* generator() {
-      yield 9;
-      yield EPromise.resolve(8).then(res => res * 10);
-      yield Promise.resolve(7).then(res => -res);
+    // Full relay succeeds.
+    const fullObj = {};
+    t.equal(
+      await EPromise.makeRemote(resolve => resolve(fullObj, relay)),
+      fullObj,
+    );
+
+    // Primitive relay fails.
+    try {
+      t.assert(
+        (await EPromise.makeRemote(resolve => resolve({}, 123))) && false,
+      );
+    } catch (e) {
+      t.throws(() => {
+        throw e;
+      }, /cannot be a primitive/);
     }
+
+    // Relay missing a method fails.
+    for (const method of Object.keys(relay)) {
+      const { [method]: elide, ...relay2 } = relay;
+      t.equal(elide, relay[method]);
+      try {
+        t.assert(
+          // eslint-disable-next-line no-await-in-loop
+          (await EPromise.makeRemote(resolve => resolve({}, relay2))) && false,
+        );
+      } catch (e) {
+        t.throws(() => {
+          throw e;
+        }, new RegExp(`requires a ${method} method`));
+      }
+    }
+
+    // Primitive resolve fails.
+    try {
+      t.assert(
+        (await EPromise.makeRemote(resolve => resolve(123, relay))) && false,
+      );
+    } catch (e) {
+      t.throws(() => {
+        throw e;
+      }, /cannot be a primitive/);
+    }
+
+    // Promise resolve fails.
+    const promise = EPromise.resolve({});
+    try {
+      t.assert(
+        (await EPromise.makeRemote(resolve => resolve(promise, relay))) &&
+          false,
+      );
+    } catch (e) {
+      t.throws(() => {
+        throw e;
+      }, /cannot be a Promise/);
+    }
+
+    // First resolve succeeds but second resolve fails.
+    const obj = {};
+    t.assert(await EPromise.makeRemote(resolve => resolve(obj, relay)));
+    try {
+      t.assert(
+        (await EPromise.makeRemote(resolve => resolve(obj, relay))) && false,
+      );
+    } catch (e) {
+      t.throws(() => {
+        throw e;
+      }, /is already mapped/);
+    }
+  } catch (e) {
+    t.assert(false, `Unexpected exception ${e}`);
+  } finally {
+    t.end();
+  }
+});
+
+test('EPromise.makeRemote(executor, undefined)', async t => {
+  try {
+    const EPromise = makeEPromiseClass(Promise);
+
+    const remoteP = EPromise.makeRemote(resolve => {
+      setTimeout(() => {
+        const o = {
+          num: 123,
+          str: 'my string',
+          hello(name) {
+            return `Hello, ${name}!`;
+          },
+        };
+
+        const resolvedRelay = {
+          GET(p, key) {
+            return o[key];
+          },
+          PUT(p, key, value) {
+            return (o[key] = value);
+          },
+          DELETE(p, key) {
+            return delete o[key];
+          },
+          POST(p, key, args) {
+            return o[key](...args);
+          },
+        };
+        resolve({}, resolvedRelay);
+      }, 200);
+    });
+
+    t.equal(await remoteP.get('str'), 'my string');
+    t.equal(await remoteP.get('num'), 123);
+    t.equal(await remoteP.put('num', 789), 789);
+    t.equal(await remoteP.get('num'), 789);
+    t.equal(await remoteP.delete('str'), true);
+    t.equal(await remoteP.get('str'), undefined);
+    t.equal(await remoteP.delete('str'), true);
+    t.equal(await remoteP.get('str'), undefined);
+    t.equal(await remoteP.invoke('hello', 'World'), 'Hello, World!');
+  } catch (e) {
+    t.assert(false, `Unexpected exception ${e}`);
+  } finally {
+    t.end();
+  }
+});
+
+test('EPromise.all', async t => {
+  let EPromise;
+  function* generator() {
+    yield 9;
+    yield EPromise.resolve(8).then(res => res * 10);
+    yield Promise.resolve(7).then(res => -res);
+  }
+
+  try {
+    EPromise = makeEPromiseClass(Promise);
+
+    t.deepEqual(await EPromise.all([1, Promise.resolve(2), 3]), [1, 2, 3]);
     t.deepEqual(await EPromise.all(generator()), [9, 80, -7]);
 
     // Ensure that a rejected promise rejects all.
@@ -41,8 +185,17 @@ test('EPromise.all', async t => {
 });
 
 test('EPromise.allSettled', async t => {
+  let EPromise;
+  let shouldThrow;
+  function* generator() {
+    yield 9;
+    shouldThrow = Error('expected');
+    yield EPromise.reject(shouldThrow).catch(_ => 80);
+    yield Promise.resolve(7).then(res => -res);
+  }
+
   try {
-    const EPromise = makeEPromiseClass(Promise);
+    EPromise = makeEPromiseClass(Promise);
 
     t.deepEqual(await EPromise.allSettled([1, Promise.resolve(2), 3]), [
       { status: 'fulfilled', value: 1 },
@@ -50,14 +203,6 @@ test('EPromise.allSettled', async t => {
       { status: 'fulfilled', value: 3 },
     ]);
 
-    let shouldThrow;
-    // eslint-disable-next-line no-inner-declarations
-    function* generator() {
-      yield 9;
-      shouldThrow = Error('expected');
-      yield EPromise.reject(shouldThrow).catch(_ => 80);
-      yield Promise.resolve(7).then(res => -res);
-    }
     t.deepEqual(await EPromise.allSettled(generator()), [
       { status: 'fulfilled', value: 9 },
       { status: 'fulfilled', value: 80 },
@@ -82,12 +227,20 @@ test('EPromise.allSettled', async t => {
 });
 
 test('EPromise.race', async t => {
+  let EPromise;
+  let shouldThrow;
+  const delay = (value, millis, ...args) =>
+    new EPromise(resolve => setTimeout(() => resolve(value), millis), ...args);
+
+  function* generator() {
+    yield delay(9, 500);
+    shouldThrow = Error('expected');
+    yield EPromise.reject(shouldThrow);
+    yield delay(7, 1000);
+  }
+
   try {
-    const EPromise = makeEPromiseClass(Promise);
-    // eslint-disable-next-line no-inner-declarations
-    function delay(value, millis) {
-      return new EPromise(resolve => setTimeout(() => resolve(value), millis));
-    }
+    EPromise = makeEPromiseClass(Promise);
 
     try {
       t.equal(await EPromise.race([1, delay(2, 1000), delay(3, 500)]), 1);
@@ -95,14 +248,6 @@ test('EPromise.race', async t => {
       t.assert(false, `unexpected exception ${e}`);
     }
 
-    let shouldThrow;
-    // eslint-disable-next-line no-inner-declarations
-    function* generator() {
-      yield delay(9, 500);
-      shouldThrow = Error('expected');
-      yield EPromise.reject(shouldThrow);
-      yield delay(7, 1000);
-    }
     try {
       t.assert((await EPromise.race(generator())) && false);
     } catch (e) {


### PR DESCRIPTION
closes #4

Change `EPromise.makeRemote` to use the executor API.