### PR TITLE
Force all handlers to run in a future turn

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,44 +22,57 @@ export default function maybeExtendPromise(Promise) {
   // This special handler accepts Promises, and forwards
   // handled Promises to their corresponding fulfilledHandler.
   let forwardingHandler;
-  function handler(p, operation, ...args) {
-    const h = promiseToHandler.get(p) || forwardingHandler;
-    if (typeof h[operation] !== 'function') {
-      const handlerName = h === forwardingHandler ? 'forwardingHandler' : 'unfulfilledHandler';
-      throw TypeError(`${handlerName}.${operation} is not a function`);
+  function handle(p, operation, ...args) {
+    const unfulfilledHandler = promiseToHandler.get(p);
+    if (unfulfilledHandler) {
+      if (typeof unfulfilledHandler[operation] !== 'function') {
+        throw TypeError(`unfulfilledHandler.${operation} is not a function`);
+      }
+      // We pass the Promise directly, but we need to ensure we
+      // run in a future turn, to prevent synchronous attacks.
+      return Promise.resolve().then(() =>
+        unfulfilledHandler[operation](p, ...args),
+      );
     }
-    return h[operation](p, ...args);
+
+    // We use the forwardingHandler, but pass in the naked object in a future turn.
+    if (typeof forwardingHandler[operation] !== 'function') {
+      throw TypeError(`forwardingHandler.${operation} is not a function`);
+    }
+    return Promise.resolve(p).then(o =>
+      forwardingHandler[operation](o, ...args),
+    );
   }
 
   Object.defineProperties(
     Promise.prototype,
     Object.getOwnPropertyDescriptors({
       get(key) {
-        return handler(this, 'GET', key);
+        return handle(this, 'GET', key);
       },
 
       put(key, val) {
-        return handler(this, 'PUT', key, val);
+        return handle(this, 'PUT', key, val);
       },
 
       delete(key) {
-        return handler(this, 'DELETE', key);
+        return handle(this, 'DELETE', key);
       },
 
       post(optKey, args) {
-        return handler(this, 'POST', optKey, args);
+        return handle(this, 'POST', optKey, args);
       },
 
       invoke(optKey, ...args) {
-        return handler(this, 'POST', optKey, args);
+        return handle(this, 'POST', optKey, args);
       },
 
       fapply(args) {
-        return handler(this, 'POST', undefined, args);
+        return handle(this, 'POST', undefined, args);
       },
 
       fcall(...args) {
-        return handler(this, 'POST', undefined, args);
+        return handle(this, 'POST', undefined, args);
       },
     }),
   );
@@ -210,19 +223,18 @@ export default function maybeExtendPromise(Promise) {
   );
 
   function makeForwarder(operation, localImpl) {
-    return async (ep, ...args) => {
-      const o = await ep;
+    return (o, ...args) => {
+      // We are in another turn already, and have the naked object.
       const fulfilledHandler = presenceToHandler.get(o);
       if (fulfilledHandler) {
-        // The handler was resolved, so give it a naked object.
+        // The handler was resolved, so use it.
         if (typeof fulfilledHandler[operation] !== 'function') {
           throw TypeError(`fulfilledHandler.${operation} is not a function`);
         }
         return fulfilledHandler[operation](o, ...args);
       }
 
-      // Not a handled Promise, so use the local implementation on the
-      // naked object.
+      // Not handled, so use the local implementation.
       return localImpl(o, ...args);
     };
   }

--- a/src/index.js
+++ b/src/index.js
@@ -25,11 +25,10 @@ export default function maybeExtendPromise(Promise) {
   function handler(p, operation, ...args) {
     const h = promiseToHandler.get(p) || forwardingHandler;
     if (typeof h[operation] !== 'function') {
-      const handlerName =
-        h === forwardingHandler ? 'forwardingHandler' : 'unfulfilledHandler';
+      const handlerName = h === forwardingHandler ? 'forwardingHandler' : 'unfulfilledHandler';
       throw TypeError(`${handlerName}.${operation} is not a function`);
     }
-    return Promise.resolve(h[operation](p, ...args));
+    return h[operation](p, ...args);
   }
 
   Object.defineProperties(
@@ -180,13 +179,13 @@ export default function maybeExtendPromise(Promise) {
 
             // Just like platform Promises, multiple calls to resolve don't fail.
             if (!presenceToHandler.has(presence)) {
+              // Create table entries for the presence mapped to the fulfilledHandler.
               presenceToPromise.set(presence, handledP);
               presenceToHandler.set(presence, fulfilledHandler);
             }
 
-            // We need to invoke fulfilledHandler immediately, so add it
-            // to the mapping.
-            promiseToHandler.set(handledP, fulfilledHandler);
+            // Remove the mapping, as our fulfilledHandler should be used instead.
+            promiseToHandler.delete(handledP);
 
             // We committed to this presence, so resolve.
             handledResolve(presence);

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,61 @@ if (typeof window !== 'undefined') {
   });
 }
 
+test('handlers are always async', async t => {
+  try {
+    const EPromise = maybeExtendPromise(Promise);
+
+    const queue = [];
+    const handler = {
+      POST(_o, fn, args) {
+        queue.push([fn, args]);
+        return 'foo';
+      },
+    };
+    let resolver;
+    const ep = EPromise.makeHandled(resolve => {
+      resolver = resolve;
+    }, handler);
+
+    // Make sure asynchronous posts go through.
+    const firstPost = ep.post('myfn', ['abc', 123]).then(v => {
+      t.equal(v, 'foo', 'post return value is foo');
+      t.deepEqual(queue, [['myfn', ['abc', 123]]], 'single post in queue');
+    });
+
+    t.deepEqual(queue, [], 'unfulfilled post is asynchronous');
+    await firstPost;
+    t.deepEqual(
+      queue,
+      [['myfn', ['abc', 123]]],
+      'single post in queue after await',
+    );
+
+    const target = {};
+    resolver(target, handler);
+    const secondPost = ep.post('myotherfn', ['def', 456]).then(v => {
+      t.equal(v, 'foo', 'second post return value is foo');
+      t.deepEqual(
+        queue,
+        [['myfn', ['abc', 123]], ['myotherfn', ['def', 456]]],
+        'second post is queued',
+      );
+    });
+
+    t.deepEqual(queue, [['myfn', ['abc', 123]]], 'second post is asynchronous');
+    await secondPost;
+    t.deepEqual(
+      queue,
+      [['myfn', ['abc', 123]], ['myotherfn', ['def', 456]]],
+      'second post is queued after await',
+    );
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
 test('maybeExtendPromise will not overwrite', async t => {
   try {
     const { makeHandled: secondMakeHandled } = maybeExtendPromise(Promise);

--- a/test/test.js
+++ b/test/test.js
@@ -12,49 +12,6 @@ if (typeof window !== 'undefined') {
   });
 }
 
-test('immediate forwarding', async t => {
-  try {
-    const EPromise = maybeExtendPromise(Promise);
-
-    const queue = [];
-    const handler = {
-      POST(_o, fn, args) {
-        queue.push([fn, args]);
-        return 'foo';
-      },
-    };
-    let resolver;
-    const ep = EPromise.makeHandled(resolve => {
-      resolver = resolve;
-    }, handler);
-
-    // Make sure asynchronous posts go through.
-    const expected = [['myfn', ['abc', 123]]];
-    const firstPost = ep.post('myfn', ['abc', 123]).then(v => {
-      t.equal(v, 'foo', 'post return value is foo');
-      t.deepEqual(queue, expected, 'single post in queue');
-    });
-
-    t.deepEqual(queue, expected, 'unfulfilled post is synchronous');
-    await firstPost;
-
-    const target = {};
-    resolver(target, handler);
-    expected.push(['myotherfn', ['def', 456]]);
-    const secondPost = ep.post('myotherfn', ['def', 456]).then(v => {
-      t.equal(v, 'foo', 'second post return value is foo');
-      t.deepEqual(queue, expected, 'second post is queued');
-    });
-
-    t.deepEqual(queue, expected, 'fulfilled post is synchronous');
-    await secondPost;
-  } catch (e) {
-    t.assert(false, e);
-  } finally {
-    t.end();
-  }
-});
-
 test('maybeExtendPromise will not overwrite', async t => {
   try {
     const { makeHandled: secondMakeHandled } = maybeExtendPromise(Promise);


### PR DESCRIPTION
fixes #19

This patch also contains the explicit understanding that unfulfilledHandlers are run against the handled promise, whereas fulfilledHandlers (and the forwardingHandler) are run against the naked object.

Since these are different cases, they have different paths and ensure that both handlers are run in exactly the next turn.

