### PR TITLE
sort out unfulfilled handlers and forwarding

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ version: 2.0
 jobs:
   lint_and_test:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:11
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Refinements always to return proper handled promises, while forwarding the unfulfilled handlers to permit pipelining.
