### PR TITLE
comments within 80 columns when possible

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
 /**
- * Modify a Promise class to have it support eventual send (infix-bang) operations.
+ * Modify a Promise class to have it support eventual send
+ * (infix-bang) operations.
  *
- * Based heavily on nanoq https://github.com/drses/nanoq/blob/master/src/nanoq.js
+ * Based heavily on nanoq
+ * https://github.com/drses/nanoq/blob/master/src/nanoq.js
  *
  * Original spec for the infix-bang desugaring:
  * https://web.archive.org/web/20161026162206/http://wiki.ecmascript.org/doku.php?id=strawman:concurrency
@@ -10,7 +12,8 @@
  * @return {typeof EPromise} Extended promise
  */
 export default function maybeExtendPromise(Promise) {
-  // Make idempotent, so we don't layer on top of a BasePromise that is adequate.
+  // Make idempotent, so we don't layer on top of a BasePromise that
+  // is adequate.
   if (typeof Promise.makeHandled === 'function') {
     return Promise;
   }
@@ -41,7 +44,8 @@ export default function maybeExtendPromise(Promise) {
       });
     }
 
-    // We use the forwardingHandler, but pass in the naked object in a future turn.
+    // We use the forwardingHandler, but pass in the naked object in a
+    // future turn.
     if (typeof forwardingHandler[operation] !== 'function') {
       throw TypeError(`forwardingHandler.${operation} is not a function`);
     }
@@ -112,7 +116,8 @@ export default function maybeExtendPromise(Promise) {
           // fulfilledHandler is set.
           //
           // This is insufficient for actual remote handled Promises
-          // (too many round-trips), but is an easy way to create a local handled Promise.
+          // (too many round-trips), but is an easy way to create a
+          // local handled Promise.
           const interlockP = new Promise(resolve => {
             continueForwarding = (targetP = undefined) => {
               // Box the target promise so that it isn't further resolved.
@@ -205,14 +210,17 @@ export default function maybeExtendPromise(Promise) {
               );
             }
 
-            // Just like platform Promises, multiple calls to resolve don't fail.
+            // Just like platform Promises, multiple calls to resolve
+            // don't fail.
             if (!presenceToHandler.has(presence)) {
-              // Create table entries for the presence mapped to the fulfilledHandler.
+              // Create table entries for the presence mapped to the
+              // fulfilledHandler.
               presenceToPromise.set(presence, handledP);
               presenceToHandler.set(presence, fulfilledHandler);
             }
 
-            // Remove the mapping, as our fulfilledHandler should be used instead.
+            // Remove the mapping, as our fulfilledHandler should be
+            // used instead.
             promiseToHandler.delete(handledP);
 
             // We committed to this presence, so resolve.


### PR DESCRIPTION
Submitting as based on no-forwarding-recursion as that seems to be the good one. Yes?
If so, I'll shortly be submitting a few more PRs that build on this one.

Is there any way to get eslint to reformat comments to 80 columns when possible automatically? Or at least to warn if there are such reformattable comment lines that exceed 80 columns?