### PR TITLE
WIP: Add antiResolve

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -125,8 +125,8 @@ export default function maybeExtendPromise(Promise) {
       // ability to tell, from the client side, whether a promise is
       // handled. Or, at least, the ability to tell given that the
       // promise is already fulfilled.
-      antiResolve(promise) {
-        return promiseToPresence.get(promise);
+      antiResolve(value) {
+        return promiseToPresence.get(Promise.resolve(value));
       },
 
       makeHandled(executor, unfulfilledHandler = undefined) {


### PR DESCRIPTION
WIP Adds a `Promise.antiResolve(promise) -> presence` static method to `Promise`, to provide synchronous access from a fulfilled handled promise to its fulfillment. This would enable, for example, `Purse.depositAll(paymentP)` to avoid an extra turn by insisting that `Promise.antiResolve(paymentP)` not be undefined. In that case, it should be the payment itself, which can then be handled synchronously.

Avoiding the extra turn in that case makes it possible for the purse to process such messages in the order then come in, and makes it possible for the client, in the common case, to avoid forcing a round trip which would lose the benefits of promise pipelining.

WIP because of missing tests, need to bikeshed name and where to put it, and explaining better what this is and why it is needed. Not a candidate for merging until then, but making available as a pull request now to gather feedback.