### PR TITLE
fix infinite recursion in postponed handler

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,12 +29,14 @@ export default function maybeExtendPromise(Promise) {
         throw TypeError(`unfulfilledHandler.${operation} is not a function`);
       }
 
-      return Promise.makeHandled(resolve => {
+      return Promise.makeHandled((resolve, reject) => {
         // We run in a future turn to prevent synchronous attacks,
-        Promise.resolve().then(() =>
-          // and resolve to the answer from the unfulfilled handler,
-          resolve(unfulfilledHandler[operation](p, ...args)),
-        );
+        Promise.resolve()
+          .then(() =>
+            // and resolve to the answer from the unfulfilled handler,
+            resolve(unfulfilledHandler[operation](p, ...args)),
+          )
+          .catch(reject);
         // with the default unfulfilled forwarding handler.
       });
     }
@@ -99,7 +101,7 @@ export default function maybeExtendPromise(Promise) {
       makeHandled(executor, unfulfilledHandler = undefined) {
         let handledResolve;
         let handledReject;
-        let continueForwarding;
+        let continueForwarding = () => {};
         const handledP = new Promise((resolve, reject) => {
           handledResolve = resolve;
           handledReject = reject;
@@ -112,26 +114,34 @@ export default function maybeExtendPromise(Promise) {
           // This is insufficient for actual remote handled Promises
           // (too many round-trips), but is an easy way to create a local handled Promise.
           const interlockP = new Promise(resolve => {
-            continueForwarding = () => resolve(null);
+            continueForwarding = (targetP = undefined) => {
+              // Box the target promise so that it isn't further resolved.
+              resolve([targetP]);
+              // Return undefined.
+            };
           });
 
-          const postpone = forwardedOperation => {
+          const makePostponed = postponedOperation => {
             // Just wait until the handler is resolved/rejected.
-            return (x, ...args) => {
-              // console.log(`forwarding ${forwardedOperation}`);
-              return Promise.makeHandled(resolve => {
-                interlockP.then(() => {
-                  resolve(x[forwardedOperation](...args));
-                });
+            return function postpone(x, ...args) {
+              // console.log(`forwarding ${postponedOperation}`);
+              return Promise.makeHandled((resolve, reject) => {
+                interlockP
+                  .then(([targetP]) => {
+                    // If targetP is a handled promise, use it, otherwise x.
+                    const nextPromise = targetP || x;
+                    resolve(nextPromise[postponedOperation](...args));
+                  })
+                  .catch(reject);
               });
             };
           };
 
           unfulfilledHandler = {
-            GET: postpone('get'),
-            PUT: postpone('put'),
-            DELETE: postpone('delete'),
-            POST: postpone('post'),
+            GET: makePostponed('get'),
+            PUT: makePostponed('put'),
+            DELETE: makePostponed('delete'),
+            POST: makePostponed('post'),
           };
         }
 
@@ -146,21 +156,11 @@ export default function maybeExtendPromise(Promise) {
         promiseToHandler.set(handledP, unfulfilledHandler);
 
         function rejectHandled(reason) {
-          if (continueForwarding) {
-            continueForwarding();
-          }
+          continueForwarding();
           handledReject(reason);
         }
 
         async function resolveHandled(target, fulfilledHandler) {
-          const doContinue = () => {
-            if (continueForwarding) {
-              // Tell the default unfulfilledHandler to forward messages.
-              continueForwarding();
-            }
-            // Return undefined.
-          };
-
           try {
             // Sanity checks.
             if (fulfilledHandler) {
@@ -168,14 +168,14 @@ export default function maybeExtendPromise(Promise) {
             }
 
             if (!fulfilledHandler) {
-              // Resolve with the target.
+              // Resolve with the target when it's ready.
               handledResolve(target);
 
               const existingUnfulfilledHandler = promiseToHandler.get(target);
               if (existingUnfulfilledHandler) {
                 // Reuse the unfulfilled handler.
                 promiseToHandler.set(handledP, existingUnfulfilledHandler);
-                return doContinue();
+                return continueForwarding(target);
               }
 
               // See if the target is a presence we already know of.
@@ -183,12 +183,12 @@ export default function maybeExtendPromise(Promise) {
               const existingFulfilledHandler = presenceToHandler.get(presence);
               if (existingFulfilledHandler) {
                 promiseToHandler.set(handledP, existingFulfilledHandler);
-                return doContinue();
+                return continueForwarding();
               }
 
               // Remove the mapping, as we don't need a handler.
               promiseToHandler.delete(handledP);
-              return doContinue();
+              return continueForwarding();
             }
 
             // Validate and install our mapped target (i.e. presence).
@@ -218,13 +218,15 @@ export default function maybeExtendPromise(Promise) {
             // We committed to this presence, so resolve.
             handledResolve(presence);
           } catch (e) {
-            rejectHandled(e);
+            handledReject(e);
           }
-          return doContinue();
+          return continueForwarding();
         }
 
         // Invoke the callback to let the user resolve/reject.
-        executor(resolveHandled, rejectHandled);
+        executor((...args) => {
+          resolveHandled(...args);
+        }, rejectHandled);
 
         // Return a handled Promise, which wil be resolved/rejected
         // by the executor.

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,22 @@ if (typeof window !== 'undefined') {
   });
 }
 
+test('reject/resolve returns undefined', async t => {
+  try {
+    const EPromise = maybeExtendPromise(Promise);
+    const ret = await EPromise.makeHandled((resolve, reject) => {
+      t.equal(resolve(123), undefined, 'resolver undefined');
+      t.equal(reject(999), undefined, 'rejector undefined');
+    });
+    t.equal(ret, 123, 'resolved value');
+  } catch (e) {
+    console.log('unexpected exception', e);
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
 test('handlers are always async', async t => {
   try {
     const EPromise = maybeExtendPromise(Promise);


### PR DESCRIPTION
The main issue was that the postponed handler needs to be aware of
the unfulfilled handler of the resolved target.  If there is an
unfulfilled handler, forward to it, otherwise wait for the original
promise to fulfill.